### PR TITLE
Allow configuring the Ollama base URL

### DIFF
--- a/NotesOllama/Services/OllamaService.swift
+++ b/NotesOllama/Services/OllamaService.swift
@@ -9,10 +9,18 @@ import Foundation
 import OllamaKit
 import Combine
 
-let OLLAMA_BASE_URL = "http://localhost:11434"
+let defaultBaseURL = "http://localhost:11434"
 
 class OllamaService {
-    private var ollamaKit = OllamaKit(baseURL: URL(string: OLLAMA_BASE_URL)!)
+    private var ollamaKit: OllamaKit
+
+    init() {
+        let baseURLString = ProcessInfo.processInfo.environment["NOTESOLLAMA_OLLAMA_BASE_URL"] ?? defaultBaseURL
+        guard let url = URL(string: baseURLString) else {
+            fatalError("Invalid URL string: \(baseURLString)")
+        }
+        self.ollamaKit = OllamaKit(baseURL: url)
+    }
 
     private var cancellables = Set<AnyCancellable>()
     


### PR DESCRIPTION
The Ollama base URL is loaded from the environment variable `NOTESOLLAMA_OLLAMA_BASE_URL` if it is defined. If not, it falls back to the default URL (http://localhost:11434).

This fixes #7 